### PR TITLE
Implement REEF Driver in AzBatch runtime

### DIFF
--- a/lang/java/reef-runtime-azbatch/pom.xml
+++ b/lang/java/reef-runtime-azbatch/pom.xml
@@ -43,6 +43,11 @@ under the License.
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>reef-runtime-hdinsight</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/AzureBatchClasspathProvider.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/AzureBatchClasspathProvider.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.runime.azbatch;
+
+import org.apache.reef.runtime.common.files.RuntimeClasspathProvider;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Access to the classpath according to the REEF file system standard.
+ */
+public class AzureBatchClasspathProvider implements RuntimeClasspathProvider {
+
+  private final List<String> classPathPrefix;
+  private final List<String> classPathSuffix;
+
+  @Inject
+  AzureBatchClasspathProvider() {
+    this.classPathPrefix = new ArrayList<>();
+    this.classPathSuffix = new ArrayList<>();
+  }
+
+  @Override
+  public List<String> getDriverClasspathPrefix() {
+    return this.classPathPrefix;
+  }
+
+  @Override
+  public List<String> getDriverClasspathSuffix() {
+    return this.classPathSuffix;
+  }
+
+  @Override
+  public List<String> getEvaluatorClasspathPrefix() {
+    return this.classPathPrefix;
+  }
+
+  @Override
+  public List<String> getEvaluatorClasspathSuffix() {
+    return this.classPathSuffix;
+  }
+}

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/client/AzureBatchJobSubmissionHandler.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/client/AzureBatchJobSubmissionHandler.java
@@ -18,6 +18,7 @@
  */
 package org.apache.reef.runime.azbatch.client;
 
+import com.microsoft.azure.batch.protocol.models.BatchErrorException;
 import org.apache.commons.lang.StringUtils;
 import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.runime.azbatch.parameters.AzureBatchAccountKey;
@@ -142,6 +143,9 @@ public final class AzureBatchJobSubmissionHandler implements JobSubmissionHandle
     } catch (final IOException ex) {
       LOG.log(Level.SEVERE, "Error submitting Azure Batch request", ex);
       throw new RuntimeException(ex);
+    } catch (final BatchErrorException ex) {
+      LOG.log(Level.SEVERE, "An error occurred while calling Azure Batch", ex);
+      throw ex;
     }
   }
 

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/client/AzureBatchJobSubmissionHandler.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/client/AzureBatchJobSubmissionHandler.java
@@ -18,18 +18,31 @@
  */
 package org.apache.reef.runime.azbatch.client;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.runime.azbatch.parameters.AzureBatchAccountKey;
 import org.apache.reef.runime.azbatch.parameters.AzureBatchAccountName;
 import org.apache.reef.runime.azbatch.parameters.AzureBatchAccountUri;
 import org.apache.reef.runime.azbatch.parameters.AzureBatchPoolId;
+import org.apache.reef.runtime.common.client.DriverConfigurationProvider;
 import org.apache.reef.runtime.common.client.api.JobSubmissionEvent;
 import org.apache.reef.runtime.common.client.api.JobSubmissionHandler;
+import org.apache.reef.runtime.common.files.ClasspathProvider;
+import org.apache.reef.runtime.common.files.JobJarMaker;
+import org.apache.reef.runtime.common.files.REEFFileNames;
+import org.apache.reef.runtime.hdinsight.client.AzureUploader;
+import org.apache.reef.runtime.hdinsight.client.yarnrest.LocalResource;
+import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.annotations.Parameter;
 
 import javax.inject.Inject;
+import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -39,59 +52,129 @@ import java.util.logging.Logger;
 @Private
 public final class AzureBatchJobSubmissionHandler implements JobSubmissionHandler {
 
-    private static final Logger LOG = Logger.getLogger(AzureBatchJobSubmissionHandler.class.getName());
+  private static final Logger LOG = Logger.getLogger(AzureBatchJobSubmissionHandler.class.getName());
 
-    private final String applicationId;
+  private final String applicationId;
 
-    private final String azureBatchAccountUri;
-    private final String azureBatchAccountName;
-    private final String azureBatchAccountKey;
-    private final String azureBatchPoolId;
+  private final AzureUploader azureUploader;
+  private final ClasspathProvider classpathProvider;
+  private final DriverConfigurationProvider driverConfigurationProvider;
+  private final JobJarMaker jobJarMaker;
+  private final REEFFileNames reefFileNames;
 
-    @Inject
-    AzureBatchJobSubmissionHandler(
-            @Parameter(AzureBatchAccountUri.class) final String azureBatchAccountUri,
-            @Parameter(AzureBatchAccountName.class) final String azureBatchAccountName,
-            @Parameter(AzureBatchAccountKey.class) final String azureBatchAccountKey,
-            @Parameter(AzureBatchPoolId.class) final String azureBatchPoolId) {
-        this.azureBatchAccountUri = azureBatchAccountUri;
-        this.azureBatchAccountName = azureBatchAccountName;
-        this.azureBatchAccountKey = azureBatchAccountKey;
-        this.azureBatchPoolId = azureBatchPoolId;
+  private final String azureBatchAccountUri;
+  private final String azureBatchAccountName;
+  private final String azureBatchAccountKey;
+  private final String azureBatchPoolId;
 
-        this.applicationId = "HelloWorldJob-"
-                + this.azureBatchAccountName + "-"
-                + (new Date()).toString()
-                .replace(' ', '-')
-                .replace(':', '-')
-                .replace('.', '-');
+  @Inject
+  AzureBatchJobSubmissionHandler(
+      final AzureUploader azureUploader,
+      final ClasspathProvider classpathProvider,
+      final DriverConfigurationProvider driverConfigurationProvider,
+      final JobJarMaker jobJarMaker,
+      final REEFFileNames reefFileNames,
+      @Parameter(AzureBatchAccountUri.class) final String azureBatchAccountUri,
+      @Parameter(AzureBatchAccountName.class) final String azureBatchAccountName,
+      @Parameter(AzureBatchAccountKey.class) final String azureBatchAccountKey,
+      @Parameter(AzureBatchPoolId.class) final String azureBatchPoolId) {
+    this.azureUploader = azureUploader;
+    this.classpathProvider = classpathProvider;
+    this.driverConfigurationProvider = driverConfigurationProvider;
+    this.jobJarMaker = jobJarMaker;
+    this.reefFileNames = reefFileNames;
+
+    this.azureBatchAccountUri = azureBatchAccountUri;
+    this.azureBatchAccountName = azureBatchAccountName;
+    this.azureBatchAccountKey = azureBatchAccountKey;
+    this.azureBatchPoolId = azureBatchPoolId;
+
+    this.applicationId = "HelloWorldJob-"
+        + this.azureBatchAccountName + "-"
+        + (new Date()).toString()
+        .replace(' ', '-')
+        .replace(':', '-')
+        .replace('.', '-');
+  }
+
+  @Override
+  public String getApplicationId() {
+    return this.applicationId;
+  }
+
+  @Override
+  public void close() throws Exception {
+    LOG.log(Level.INFO, "Closing " + AzureBatchJobSubmissionHandler.class.getName());
+  }
+
+  @Override
+  public void onNext(final JobSubmissionEvent jobSubmissionEvent) {
+
+    LOG.log(Level.FINEST, "Submitting job: {0}", jobSubmissionEvent);
+
+    try (final AzureBatchJobSubmissionHelper helper = new AzureBatchJobSubmissionHelper(
+        this.azureBatchAccountUri,
+        this.azureBatchAccountName,
+        this.azureBatchAccountKey,
+        this.azureBatchPoolId,
+        getApplicationId())) {
+
+      final String id = jobSubmissionEvent.getIdentifier();
+
+      LOG.log(Level.FINE, "Creating a job folder on Azure.");
+      final URI jobFolderURL = this.azureUploader.createJobFolder(id);
+
+      LOG.log(Level.FINE, "Assembling Configuration for the Driver.");
+      final Configuration driverConfiguration = makeDriverConfiguration(jobSubmissionEvent, id, jobFolderURL);
+
+      LOG.log(Level.FINE, "Making Job JAR.");
+      final File jobSubmissionJarFile =
+          this.jobJarMaker.createJobSubmissionJAR(jobSubmissionEvent, driverConfiguration);
+
+      LOG.log(Level.FINE, "Uploading Job JAR to Azure.");
+      final LocalResource uploadedFile = this.azureUploader.uploadFile(jobSubmissionJarFile);
+
+      LOG.log(Level.FINE, "Assembling application submission.");
+      final String command = getCommandString(jobSubmissionEvent);
+
+      helper.submit(uploadedFile, command);
+
+    } catch (final IOException ex) {
+      LOG.log(Level.SEVERE, "Error submitting Azure Batch request", ex);
+      throw new RuntimeException(ex);
     }
+  }
 
-    @Override
-    public String getApplicationId() {
-        return this.applicationId;
-    }
+  private Configuration makeDriverConfiguration(
+      final JobSubmissionEvent jobSubmissionEvent,
+      final String appId,
+      final URI jobFolderURL) throws IOException {
 
-    @Override
-    public void close() throws Exception {
-        LOG.log(Level.INFO, "Closing " + AzureBatchJobSubmissionHandler.class.getName());
-    }
+    return this.driverConfigurationProvider.getDriverConfiguration(
+        jobFolderURL, jobSubmissionEvent.getRemoteId(), appId, jobSubmissionEvent.getConfiguration());
+  }
 
-    @Override
-    public void onNext(final JobSubmissionEvent jobSubmissionEvent) {
-        final String id = jobSubmissionEvent.getIdentifier();
-        LOG.log(Level.FINEST, "Submitting job: {0}", jobSubmissionEvent);
+  /**
+   * Assembles the command to execute the Driver in list form.
+   */
+  private List<String> getCommandList(
+      final JobSubmissionEvent jobSubmissionEvent) {
 
-        try (final AzureBatchJobSubmissionHelper helper = new AzureBatchJobSubmissionHelper(
-                this.azureBatchAccountUri,
-                this.azureBatchAccountName,
-                this.azureBatchAccountKey,
-                this.azureBatchPoolId,
-                getApplicationId())) {
-            helper.submit();
-        }
-        catch (IOException e) {
-            LOG.log(Level.WARNING, "Failed to create the Driver application.");
-        }
-    }
+    // Task 122137: Use JavaLaunchCommandBuilder to generate command to start REEF Driver
+    return Collections.unmodifiableList(Arrays.asList(
+        "/bin/sh -c \"",
+        "ln -sf '.' 'reef';",
+        "unzip local.jar;",
+        "java -Xmx256m -XX:PermSize=128m -XX:MaxPermSize=128m -classpath reef/local/*:reef/global/*",
+        "-Dproc_reef org.apache.reef.runtime.common.REEFLauncher reef/local/driver.conf",
+        "\""
+    ));
+  }
+
+  /**
+   * Assembles the command to execute the Driver.
+   */
+  private String getCommandString(final JobSubmissionEvent jobSubmissionEvent) {
+    return StringUtils.join(getCommandList(jobSubmissionEvent), ' ');
+  }
 }

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/client/AzureBatchJobSubmissionHelper.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/client/AzureBatchJobSubmissionHelper.java
@@ -1,59 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.reef.runime.azbatch.client;
 
 import com.microsoft.azure.batch.BatchClient;
 import com.microsoft.azure.batch.auth.BatchSharedKeyCredentials;
-import com.microsoft.azure.batch.protocol.models.BatchErrorException;
-import com.microsoft.azure.batch.protocol.models.JobAddParameter;
-import com.microsoft.azure.batch.protocol.models.JobManagerTask;
-import com.microsoft.azure.batch.protocol.models.PoolInformation;
+import com.microsoft.azure.batch.protocol.models.*;
+import org.apache.reef.runtime.hdinsight.client.yarnrest.LocalResource;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
+/**
+ * A {@link AzureBatchJobSubmissionHelper} for Azure Batch.
+ */
 public class AzureBatchJobSubmissionHelper implements AutoCloseable {
 
-    private final String azureBatchAccountUri;
-    private final String azureBatchAccountName;
-    private final String azureBatchAccountKey;
-    private final String azureBatchPoolId;
+  private static final Logger LOG = Logger.getLogger(AzureBatchJobSubmissionHandler.class.getName());
 
-    private final String applicationId;
+  private final String azureBatchAccountUri;
+  private final String azureBatchAccountName;
+  private final String azureBatchAccountKey;
+  private final String azureBatchPoolId;
 
-    public AzureBatchJobSubmissionHelper(
-            String azureBatchAccountUri,
-            String azureBatchAccountName,
-            String azureBatchAccountKey,
-            String azureBatchPoolId,
-            String applicationId) {
-        this.azureBatchAccountUri = azureBatchAccountUri;
-        this.azureBatchAccountName = azureBatchAccountName;
-        this.azureBatchAccountKey = azureBatchAccountKey;
-        this.azureBatchPoolId = azureBatchPoolId;
-        this.applicationId = applicationId;
-    }
+  private final String applicationId;
 
-    public void submit() throws BatchErrorException, IOException  {
+  public AzureBatchJobSubmissionHelper(
+      final String azureBatchAccountUri,
+      final String azureBatchAccountName,
+      final String azureBatchAccountKey,
+      final String azureBatchPoolId,
+      final String applicationId) {
+    this.azureBatchAccountUri = azureBatchAccountUri;
+    this.azureBatchAccountName = azureBatchAccountName;
+    this.azureBatchAccountKey = azureBatchAccountKey;
+    this.azureBatchPoolId = azureBatchPoolId;
+    this.applicationId = applicationId;
+  }
 
-        BatchSharedKeyCredentials cred = new BatchSharedKeyCredentials(
-                this.azureBatchAccountUri, this.azureBatchAccountName, this.azureBatchAccountKey);
-        BatchClient client = BatchClient.open(cred);
+  public void submit(final LocalResource uploadedFile, final String command) throws BatchErrorException, IOException {
 
-        PoolInformation poolInfo = new PoolInformation();
-        poolInfo.withPoolId(this.azureBatchPoolId);
+    BatchSharedKeyCredentials cred = new BatchSharedKeyCredentials(
+        this.azureBatchAccountUri, this.azureBatchAccountName, this.azureBatchAccountKey);
+    BatchClient client = BatchClient.open(cred);
 
-        JobManagerTask jobManagerTask = new JobManagerTask()
-                .withId(applicationId)
-                .withCommandLine("dir");
+    PoolInformation poolInfo = new PoolInformation();
+    poolInfo.withPoolId(this.azureBatchPoolId);
 
-        JobAddParameter jobAddParameter = new JobAddParameter()
-                .withId(applicationId)
-                .withJobManagerTask(jobManagerTask)
-                .withPoolInfo(poolInfo);
+    ResourceFile jarResourceFile = new ResourceFile()
+        .withBlobSource(uploadedFile.getUrl())
+        .withFilePath("local.jar");
 
-        client.jobOperations().createJob(jobAddParameter);
-    }
+    JobManagerTask jobManagerTask = new JobManagerTask()
+        .withId(applicationId)
+        .withResourceFiles(Collections.singletonList(jarResourceFile))
+        .withCommandLine(command);
 
-    @Override
-    public void close() {
+    LOG.log(Level.INFO, "Job Manager (aka driver) task command: " + command);
 
-    }
+    JobAddParameter jobAddParameter = new JobAddParameter()
+        .withId(applicationId)
+        .withJobManagerTask(jobManagerTask)
+        .withPoolInfo(poolInfo);
+
+    client.jobOperations().createJob(jobAddParameter);
+  }
+
+  @Override
+  public void close() {
+
+  }
 }

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/client/AzureBatchRuntimeConfiguration.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/client/AzureBatchRuntimeConfiguration.java
@@ -19,12 +19,13 @@
 package org.apache.reef.runime.azbatch.client;
 
 import org.apache.reef.annotations.audience.Public;
-import org.apache.reef.runime.azbatch.parameters.AzureBatchAccountKey;
-import org.apache.reef.runime.azbatch.parameters.AzureBatchAccountName;
-import org.apache.reef.runime.azbatch.parameters.AzureBatchAccountUri;
-import org.apache.reef.runime.azbatch.parameters.AzureBatchPoolId;
+import org.apache.reef.runime.azbatch.parameters.*;
+import org.apache.reef.runtime.hdinsight.parameters.AzureStorageAccountContainerName;
+import org.apache.reef.runtime.hdinsight.parameters.AzureStorageAccountKey;
+import org.apache.reef.runtime.hdinsight.parameters.AzureStorageAccountName;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.formats.AvroConfigurationSerializer;
+
 import org.apache.reef.tang.formats.ConfigurationModule;
 import org.apache.reef.tang.formats.ConfigurationModuleBuilder;
 import org.apache.reef.tang.formats.RequiredParameter;
@@ -39,22 +40,22 @@ import java.io.IOException;
 public class AzureBatchRuntimeConfiguration extends ConfigurationModuleBuilder {
 
   /**
-   * The Storage account to be used by Azure.
+   * The Azure Batch account URI to be used by REEF.
    */
   public static final RequiredParameter<String> AZURE_BATCH_ACCOUNT_URI = new RequiredParameter<>();
 
   /**
-   * The Storage account to be used by Azure.
+   * The Azure Batch account name to be used by REEF.
    */
   public static final RequiredParameter<String> AZURE_BATCH_ACCOUNT_NAME = new RequiredParameter<>();
 
   /**
-   * The Storage account to be used by Azure.
+   * The Azure Batch account key.
    */
   public static final RequiredParameter<String> AZURE_BATCH_ACCOUNT_KEY = new RequiredParameter<>();
 
   /**
-   * The Storage account to be used by Azure.
+   * The Azure Batch Pool ID.
    */
   public static final RequiredParameter<String> AZURE_BATCH_POOL_ID = new RequiredParameter<>();
 
@@ -62,6 +63,21 @@ public class AzureBatchRuntimeConfiguration extends ConfigurationModuleBuilder {
    * The environment variable that holds the path to the default configuration file.
    */
   public static final String AZBATCH_CONFIGURATION_FILE_ENVIRONMENT_VARIABLE = "REEF_AZBATCH_CONF";
+
+  /**
+   * The name of the Azure Storage account.
+   */
+  public static final RequiredParameter<String> AZURE_STORAGE_ACCOUNT_NAME = new RequiredParameter<>();
+
+  /**
+   * The key of the Azure Storage account.
+   */
+  public static final RequiredParameter<String> AZURE_STORAGE_ACCOUNT_KEY = new RequiredParameter<>();
+
+  /**
+   * The name of the Azure Storage account container.
+   */
+  public static final RequiredParameter<String> AZURE_STORAGE_CONTAINER_NAME = new RequiredParameter<>();
 
   /**
    * The ConfigurationModule for the local resourcemanager.
@@ -72,6 +88,9 @@ public class AzureBatchRuntimeConfiguration extends ConfigurationModuleBuilder {
       .bindNamedParameter(AzureBatchAccountName.class, AZURE_BATCH_ACCOUNT_NAME)
       .bindNamedParameter(AzureBatchAccountKey.class, AZURE_BATCH_ACCOUNT_KEY)
       .bindNamedParameter(AzureBatchPoolId.class, AZURE_BATCH_POOL_ID)
+      .bindNamedParameter(AzureStorageAccountName.class, AZURE_STORAGE_ACCOUNT_NAME)
+      .bindNamedParameter(AzureStorageAccountKey.class, AZURE_STORAGE_ACCOUNT_KEY)
+      .bindNamedParameter(AzureStorageAccountContainerName.class, AZURE_STORAGE_CONTAINER_NAME)
       .build();
 
   /**

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/client/AzureBatchRuntimeConfigurationStatic.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/client/AzureBatchRuntimeConfigurationStatic.java
@@ -1,12 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.reef.runime.azbatch.client;
 
+import org.apache.reef.runime.azbatch.AzureBatchClasspathProvider;
 import org.apache.reef.runtime.common.client.CommonRuntimeConfiguration;
 import org.apache.reef.runtime.common.client.DriverConfigurationProvider;
 import org.apache.reef.runtime.common.client.api.JobSubmissionHandler;
+import org.apache.reef.runtime.common.files.RuntimeClasspathProvider;
 import org.apache.reef.tang.formats.ConfigurationModule;
 import org.apache.reef.tang.formats.ConfigurationModuleBuilder;
 import org.apache.reef.util.logging.LoggingSetup;
 
+/**
+ * The static part of the AzureBatchRuntimeConfigurationStatic.
+ */
 public class AzureBatchRuntimeConfigurationStatic extends ConfigurationModuleBuilder {
   static {
     LoggingSetup.setupCommonsLogging();
@@ -14,8 +37,8 @@ public class AzureBatchRuntimeConfigurationStatic extends ConfigurationModuleBui
 
   public static final ConfigurationModule CONF = new AzureBatchRuntimeConfigurationStatic()
       .merge(CommonRuntimeConfiguration.CONF)
-      // Bind the Azure Batch runtime
       .bindImplementation(JobSubmissionHandler.class, AzureBatchJobSubmissionHandler.class)
       .bindImplementation(DriverConfigurationProvider.class, AzureBatchDriverConfigurationProviderImpl.class)
+      .bindImplementation(RuntimeClasspathProvider.class, AzureBatchClasspathProvider.class)
       .build();
 }

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchDriverConfiguration.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchDriverConfiguration.java
@@ -60,7 +60,6 @@ public class AzureBatchDriverConfiguration extends ConfigurationModuleBuilder {
    */
   public static final OptionalParameter<Double> JVM_HEAP_SLACK = new OptionalParameter<>();
 
-
   public static final ConfigurationModule CONF = new AzureBatchDriverConfiguration()
       .bindImplementation(ResourceLaunchHandler.class, AzureBatchResourceLaunchHandler.class)
       .bindImplementation(ResourceReleaseHandler.class, AzureBatchResourceReleaseHandler.class)

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchDriverConfiguration.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchDriverConfiguration.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.runime.azbatch.driver;
+
+import org.apache.reef.runime.azbatch.AzureBatchClasspathProvider;
+import org.apache.reef.runtime.common.driver.api.*;
+import org.apache.reef.runtime.common.driver.parameters.ClientRemoteIdentifier;
+import org.apache.reef.runtime.common.driver.parameters.DefinedRuntimes;
+import org.apache.reef.runtime.common.driver.parameters.EvaluatorTimeout;
+import org.apache.reef.runtime.common.driver.parameters.JobIdentifier;
+import org.apache.reef.runtime.common.files.RuntimeClasspathProvider;
+import org.apache.reef.runtime.common.launch.parameters.ErrorHandlerRID;
+import org.apache.reef.runtime.common.launch.parameters.LaunchID;
+import org.apache.reef.runtime.common.parameters.JVMHeapSlack;
+import org.apache.reef.tang.formats.*;
+
+/**
+ * ConfigurationModule to create YARN Driver configurations.
+ */
+public class AzureBatchDriverConfiguration extends ConfigurationModuleBuilder {
+
+  /**
+   * @see JobIdentifier
+   */
+  public static final RequiredParameter<String> JOB_IDENTIFIER = new RequiredParameter<>();
+
+  /**
+   * @see DefinedRuntimes
+   */
+  public static final RequiredParameter<String> RUNTIME_NAME = new RequiredParameter<>();
+
+  /**
+   * @see EvaluatorTimeout
+   */
+  public static final OptionalParameter<Long> EVALUATOR_TIMEOUT = new OptionalParameter<>();
+
+  /**
+   * The client remote identifier.
+   */
+  public static final OptionalParameter<String> CLIENT_REMOTE_IDENTIFIER = new OptionalParameter<>();
+
+  /**
+   * The fraction of the container memory NOT to use for the Java Heap.
+   */
+  public static final OptionalParameter<Double> JVM_HEAP_SLACK = new OptionalParameter<>();
+
+
+  public static final ConfigurationModule CONF = new AzureBatchDriverConfiguration()
+      .bindImplementation(ResourceLaunchHandler.class, AzureBatchResourceLaunchHandler.class)
+      .bindImplementation(ResourceReleaseHandler.class, AzureBatchResourceReleaseHandler.class)
+      .bindImplementation(ResourceRequestHandler.class, AzureBatchResourceRequestHandler.class)
+      .bindImplementation(ResourceManagerStartHandler.class, AzureBatchRuntimeStartHandler.class)
+      .bindImplementation(ResourceManagerStopHandler.class, AzureBatchRuntimeStopHandler.class)
+
+      // Bind the fields bound in AbstractDriverRuntimeConfiguration
+      .bindNamedParameter(JobIdentifier.class, JOB_IDENTIFIER)
+      .bindNamedParameter(LaunchID.class, JOB_IDENTIFIER)
+      .bindNamedParameter(EvaluatorTimeout.class, EVALUATOR_TIMEOUT)
+      .bindNamedParameter(ClientRemoteIdentifier.class, CLIENT_REMOTE_IDENTIFIER)
+      .bindNamedParameter(ErrorHandlerRID.class, CLIENT_REMOTE_IDENTIFIER)
+      .bindNamedParameter(JVMHeapSlack.class, JVM_HEAP_SLACK)
+      .bindImplementation(RuntimeClasspathProvider.class, AzureBatchClasspathProvider.class)
+      .bindSetEntry(DefinedRuntimes.class, RUNTIME_NAME)
+      .build();
+}

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchResourceLaunchHandler.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchResourceLaunchHandler.java
@@ -23,11 +23,18 @@ import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.runtime.common.driver.api.ResourceLaunchEvent;
 import org.apache.reef.runtime.common.driver.api.ResourceLaunchHandler;
 
+import javax.inject.Inject;
+
 /**
  * A {@link ResourceLaunchHandler} for Azure Batch.
  */
 @Private
 public final class AzureBatchResourceLaunchHandler implements ResourceLaunchHandler {
+
+  @Inject
+  AzureBatchResourceLaunchHandler() {
+  }
+
   @Override
   public void onNext(final ResourceLaunchEvent value) {
     throw new NotImplementedException();

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchResourceReleaseHandler.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchResourceReleaseHandler.java
@@ -23,11 +23,18 @@ import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.runtime.common.driver.api.ResourceReleaseEvent;
 import org.apache.reef.runtime.common.driver.api.ResourceReleaseHandler;
 
+import javax.inject.Inject;
+
 /**
  * A {@link ResourceReleaseHandler} for Azure Batch.
  */
 @Private
 public class AzureBatchResourceReleaseHandler implements ResourceReleaseHandler {
+
+  @Inject
+  AzureBatchResourceReleaseHandler() {
+  }
+
   @Override
   public void onNext(final ResourceReleaseEvent value) {
     throw new NotImplementedException();

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchResourceRequestHandler.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchResourceRequestHandler.java
@@ -23,11 +23,18 @@ import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.runtime.common.driver.api.ResourceRequestEvent;
 import org.apache.reef.runtime.common.driver.api.ResourceRequestHandler;
 
+import javax.inject.Inject;
+
 /**
  * A {@link ResourceRequestHandler} for Azure Batch.
  */
 @Private
 public class AzureBatchResourceRequestHandler implements ResourceRequestHandler {
+
+  @Inject
+  AzureBatchResourceRequestHandler() {
+  }
+
   @Override
   public void onNext(final ResourceRequestEvent value) {
     throw new NotImplementedException();

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchRuntimeStartHandler.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchRuntimeStartHandler.java
@@ -40,5 +40,4 @@ public class AzureBatchRuntimeStartHandler implements ResourceManagerStartHandle
   public void onNext(final RuntimeStart runtimeStart) {
     LOG.log(Level.FINE, "Azure batch runtime has been started...");
   }
-
 }

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchRuntimeStartHandler.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchRuntimeStartHandler.java
@@ -16,14 +16,29 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.runime.azbatch.parameters;
+package org.apache.reef.runime.azbatch.driver;
 
-import org.apache.reef.tang.annotations.Name;
-import org.apache.reef.tang.annotations.NamedParameter;
+import org.apache.reef.runtime.common.driver.api.ResourceManagerStartHandler;
+import org.apache.reef.wake.time.runtime.event.RuntimeStart;
+
+import javax.inject.Inject;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
- * The Azure Batch pool id.
+ * Handler of RuntimeStart for the Azure Batch Runtime.
  */
-@NamedParameter(doc = "The Azure Batch Pool Id")
-public class AzureBatchPoolId implements Name<String> {
+public class AzureBatchRuntimeStartHandler implements ResourceManagerStartHandler {
+
+  private static final Logger LOG = Logger.getLogger(AzureBatchRuntimeStartHandler.class.getName());
+
+  @Inject
+  AzureBatchRuntimeStartHandler() {
+  }
+
+  @Override
+  public void onNext(final RuntimeStart runtimeStart) {
+    LOG.log(Level.FINE, "Azure batch runtime has been started...");
+  }
+
 }

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchRuntimeStopHandler.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchRuntimeStopHandler.java
@@ -16,14 +16,28 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.runime.azbatch.parameters;
+package org.apache.reef.runime.azbatch.driver;
 
-import org.apache.reef.tang.annotations.Name;
-import org.apache.reef.tang.annotations.NamedParameter;
+import org.apache.reef.runtime.common.driver.api.ResourceManagerStopHandler;
+import org.apache.reef.wake.time.runtime.event.RuntimeStop;
+
+import javax.inject.Inject;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
- * The Azure Batch pool id.
+ * Handler of RuntimeStop for the Azure Batch Runtime.
  */
-@NamedParameter(doc = "The Azure Batch Pool Id")
-public class AzureBatchPoolId implements Name<String> {
+public class AzureBatchRuntimeStopHandler implements ResourceManagerStopHandler {
+
+  private static final Logger LOG = Logger.getLogger(AzureBatchRuntimeStopHandler.class.getName());
+
+  @Inject
+  AzureBatchRuntimeStopHandler() {
+  }
+
+  @Override
+  public void onNext(final RuntimeStop runtimeStop) {
+    LOG.log(Level.FINE, "Azure batch runtime has been stopped...");
+  }
 }

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/RuntimeIdentifier.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/RuntimeIdentifier.java
@@ -16,14 +16,20 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.runime.azbatch.parameters;
+package org.apache.reef.runime.azbatch.driver;
 
-import org.apache.reef.tang.annotations.Name;
-import org.apache.reef.tang.annotations.NamedParameter;
+import org.apache.reef.annotations.audience.Private;
 
 /**
- * The Azure Batch pool id.
+ * Runtime Identifier Implementation.
  */
-@NamedParameter(doc = "The Azure Batch Pool Id")
-public class AzureBatchPoolId implements Name<String> {
+@Private
+public final class RuntimeIdentifier {
+  /**
+   * Same value is defined on the C# side in the Org.Apache.REEF.Common.Runtime.RuntimeName.
+   */
+  public static final String RUNTIME_NAME = "AzBatch";
+
+  private RuntimeIdentifier() {
+  }
 }

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/parameters/AzureBatchAccountKey.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/parameters/AzureBatchAccountKey.java
@@ -1,8 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.reef.runime.azbatch.parameters;
 
 import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
+/**
+ * The Azure Batch account key.
+ */
 @NamedParameter(doc = "The Azure Batch account key")
 public class AzureBatchAccountKey implements Name<String> {
 }

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/parameters/AzureBatchAccountName.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/parameters/AzureBatchAccountName.java
@@ -1,8 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.reef.runime.azbatch.parameters;
 
 import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
+/**
+ * The Azure Batch account name.
+ */
 @NamedParameter(doc = "The Azure Batch Account Name")
 public class AzureBatchAccountName implements Name<String> {
 }

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/parameters/AzureBatchAccountUri.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/parameters/AzureBatchAccountUri.java
@@ -16,12 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.reef.runime.azbatch.parameters;
 
 import org.apache.reef.tang.annotations.NamedParameter;
 import org.apache.reef.tang.annotations.Name;
 
+/**
+ * The Azure Batch account URI.
+ */
 @NamedParameter(doc = "The Azure Batch Account URL")
 public class AzureBatchAccountUri implements Name<String> {
 }

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/parameters/AzureBatchAccountUri.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/parameters/AzureBatchAccountUri.java
@@ -24,6 +24,6 @@ import org.apache.reef.tang.annotations.Name;
 /**
  * The Azure Batch account URI.
  */
-@NamedParameter(doc = "The Azure Batch Account URL")
+@NamedParameter(doc = "The Azure Batch Account URI")
 public class AzureBatchAccountUri implements Name<String> {
 }

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/parameters/package-info.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/parameters/package-info.java
@@ -16,14 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.runime.azbatch.parameters;
-
-import org.apache.reef.tang.annotations.Name;
-import org.apache.reef.tang.annotations.NamedParameter;
-
 /**
- * The Azure Batch pool id.
+ * Client for the REEF runtime for Azure Batch.
  */
-@NamedParameter(doc = "The Azure Batch Pool Id")
-public class AzureBatchPoolId implements Name<String> {
-}
+package org.apache.reef.runime.azbatch.parameters;

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/AzureUploader.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/AzureUploader.java
@@ -46,10 +46,12 @@ import java.util.logging.Logger;
 
 /**
  * Helper class to upload the job JAR to Azure block storage.
+ * TODO: Task 122136: Investigate using Azure Batch application packages instead Storage to submit REEF application JAR to Batch.
+ * TODO: If we cannot use Azure Batch application packages, then this needs to be refactored into a re-usable component.
  */
 @ClientSide
 @Private
-final class AzureUploader {
+public final class AzureUploader {
 
   private static final Logger LOG = Logger.getLogger(AzureUploader.class.getName());
 
@@ -129,7 +131,8 @@ final class AzureUploader {
           .setVisibility(LocalResource.VISIBILITY_APPLICATION)
           .setSize(blobProperties.getLength())
           .setTimestamp(blobProperties.getLastModified().getTime())
-          .setResource(getFileSystemURL(jobJarBlob).toString());
+          .setResource(getFileSystemURL(jobJarBlob).toString())
+          .setUrl(jobJarBlob.getUri().toString());
 
     } catch (final URISyntaxException | StorageException e) {
       throw new IOException(e);

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/LocalResource.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/LocalResource.java
@@ -47,6 +47,8 @@ public final class LocalResource {
   private long size;
   private long timestamp;
 
+  private String url;
+
   @JsonProperty(Constants.RESOURCE)
   public String getResource() {
     return this.resource;
@@ -54,6 +56,15 @@ public final class LocalResource {
 
   public LocalResource setResource(final String resource) {
     this.resource = resource;
+    return this;
+  }
+
+  public String getUrl() {
+    return this.url;
+  }
+
+  public LocalResource setUrl(final String url) {
+    this.url = url;
     return this;
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -758,20 +758,8 @@ under the License.
             <dependency>
                 <groupId>com.microsoft.azure</groupId>
                 <artifactId>azure-batch</artifactId>
-                <version>1.0.0</version>
+                <version>3.0.0</version>
             </dependency>
-            <!--<dependency>-->
-                <!--<groupId>com.microsoft.azure</groupId>-->
-                <!--<artifactId>azure-mgmt-batch</artifactId>-->
-                <!--<version>1.4.0</version>-->
-            <!--</dependency>-->
-            <!--<dependency>-->
-                <!--<groupId>com.microsoft.azure</groupId>-->
-                <!--<artifactId>azure-client-runtime</artifactId>-->
-                <!--<version>1.0.4</version>-->
-            <!--</dependency>-->
-            <!-- End of Microsoft Azure Batch APIs -->
-            
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Two things to note about this PR:
   1. It should unblock implementation of Resource and Request Handlers for Azure Batch runtime.
   2. Currently, it uses a Storage account to pass the JAR to Azure Batch. It is recommended to use Application Packages in Azure Batch for this purpose. I have a follow-up task to look into that.
   3. Because of the above, I have deferred the refactor of AzureUploader and instead took a dependency on reef-runtime-hdinsight. If the application package approach doesn't work out, I'll refactor AzureUploader into a re-usable component that both Batch and HDInsight can use.