### PR TITLE
Submit Evaluator task to AzureBatch.

### DIFF
--- a/lang/java/reef-runtime-azbatch/pom.xml
+++ b/lang/java/reef-runtime-azbatch/pom.xml
@@ -89,7 +89,7 @@ under the License.
             <version>1.10</version>
         </dependency>
         <!-- End of Microsoft Azure Batch APIs -->
-           
+
     </dependencies>
 
     <build>

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/client/AzureBatchDriverConfigurationProviderImpl.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/client/AzureBatchDriverConfigurationProviderImpl.java
@@ -19,7 +19,8 @@
 package org.apache.reef.runime.azbatch.client;
 
 import org.apache.reef.annotations.audience.Private;
-import org.apache.reef.runime.azbatch.driver.*;
+import org.apache.reef.runime.azbatch.driver.AzureBatchDriverConfiguration;
+import org.apache.reef.runime.azbatch.driver.RuntimeIdentifier;
 import org.apache.reef.runtime.common.client.DriverConfigurationProvider;
 import org.apache.reef.runtime.common.parameters.JVMHeapSlack;
 import org.apache.reef.tang.Configuration;
@@ -52,6 +53,16 @@ public final class AzureBatchDriverConfigurationProviderImpl implements DriverCo
             .set(AzureBatchDriverConfiguration.CLIENT_REMOTE_IDENTIFIER, clientRemoteId)
             .set(AzureBatchDriverConfiguration.JVM_HEAP_SLACK, this.jvmSlack)
             .set(AzureBatchDriverConfiguration.RUNTIME_NAME, RuntimeIdentifier.RUNTIME_NAME)
+             /// TODO: Make then configurable from client side driver code
+             /// This should be set in HelloReef example DriverConfiguration.
+             /// There is Injection Exception when setting this up in DriverConfiguration or expose AzureBatchDriverConfiguration to client. Fix it.
+            .set(AzureBatchDriverConfiguration.AZURE_BATCH_ACCOUNT_URI, "")
+            .set(AzureBatchDriverConfiguration.AZURE_BATCH_ACCOUNT_NAME, "")
+            .set(AzureBatchDriverConfiguration.AZURE_BATCH_ACCOUNT_KEY, "")
+            .set(AzureBatchDriverConfiguration.AZURE_BATCH_POOL_ID, "")
+            .set(AzureBatchDriverConfiguration.AZURE_STORAGE_ACCOUNT_NAME, "")
+            .set(AzureBatchDriverConfiguration.AZURE_STORAGE_ACCOUNT_KEY, "")
+            .set(AzureBatchDriverConfiguration.AZURE_STORAGE_CONTAINER_NAME, "")
             .build(),
         applicationConfiguration);
   }

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/client/AzureBatchDriverConfigurationProviderImpl.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/client/AzureBatchDriverConfigurationProviderImpl.java
@@ -53,9 +53,10 @@ public final class AzureBatchDriverConfigurationProviderImpl implements DriverCo
             .set(AzureBatchDriverConfiguration.CLIENT_REMOTE_IDENTIFIER, clientRemoteId)
             .set(AzureBatchDriverConfiguration.JVM_HEAP_SLACK, this.jvmSlack)
             .set(AzureBatchDriverConfiguration.RUNTIME_NAME, RuntimeIdentifier.RUNTIME_NAME)
-             /// TODO: Make then configurable from client side driver code
-             /// This should be set in HelloReef example DriverConfiguration.
-             /// There is Injection Exception when setting this up in DriverConfiguration or expose AzureBatchDriverConfiguration to client. Fix it.
+            /// TODO: Make then configurable from client side driver code
+            /// This should be set in HelloReef example DriverConfiguration.
+            /// There is Injection Exception when setting this up in DriverConfiguration
+            /// or expose AzureBatchDriverConfiguration to client. Fix it.
             .set(AzureBatchDriverConfiguration.AZURE_BATCH_ACCOUNT_URI, "")
             .set(AzureBatchDriverConfiguration.AZURE_BATCH_ACCOUNT_NAME, "")
             .set(AzureBatchDriverConfiguration.AZURE_BATCH_ACCOUNT_KEY, "")

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchDriverConfiguration.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchDriverConfiguration.java
@@ -19,6 +19,10 @@
 package org.apache.reef.runime.azbatch.driver;
 
 import org.apache.reef.runime.azbatch.AzureBatchClasspathProvider;
+import org.apache.reef.runime.azbatch.parameters.AzureBatchAccountKey;
+import org.apache.reef.runime.azbatch.parameters.AzureBatchAccountName;
+import org.apache.reef.runime.azbatch.parameters.AzureBatchAccountUri;
+import org.apache.reef.runime.azbatch.parameters.AzureBatchPoolId;
 import org.apache.reef.runtime.common.driver.api.*;
 import org.apache.reef.runtime.common.driver.parameters.ClientRemoteIdentifier;
 import org.apache.reef.runtime.common.driver.parameters.DefinedRuntimes;
@@ -28,7 +32,13 @@ import org.apache.reef.runtime.common.files.RuntimeClasspathProvider;
 import org.apache.reef.runtime.common.launch.parameters.ErrorHandlerRID;
 import org.apache.reef.runtime.common.launch.parameters.LaunchID;
 import org.apache.reef.runtime.common.parameters.JVMHeapSlack;
-import org.apache.reef.tang.formats.*;
+import org.apache.reef.runtime.hdinsight.parameters.AzureStorageAccountContainerName;
+import org.apache.reef.runtime.hdinsight.parameters.AzureStorageAccountKey;
+import org.apache.reef.runtime.hdinsight.parameters.AzureStorageAccountName;
+import org.apache.reef.tang.formats.ConfigurationModule;
+import org.apache.reef.tang.formats.ConfigurationModuleBuilder;
+import org.apache.reef.tang.formats.OptionalParameter;
+import org.apache.reef.tang.formats.RequiredParameter;
 
 /**
  * ConfigurationModule to create YARN Driver configurations.
@@ -56,6 +66,41 @@ public class AzureBatchDriverConfiguration extends ConfigurationModuleBuilder {
   public static final OptionalParameter<String> CLIENT_REMOTE_IDENTIFIER = new OptionalParameter<>();
 
   /**
+   * The Azure Batch account URI to be used by REEF.
+   */
+  public static final RequiredParameter<String> AZURE_BATCH_ACCOUNT_URI = new RequiredParameter<>();
+
+  /**
+   * The Azure Batch account name to be used by REEF.
+   */
+  public static final RequiredParameter<String> AZURE_BATCH_ACCOUNT_NAME = new RequiredParameter<>();
+
+  /**
+   * The Azure Batch account key.
+   */
+  public static final RequiredParameter<String> AZURE_BATCH_ACCOUNT_KEY = new RequiredParameter<>();
+
+  /**
+   * The Azure Batch Pool ID.
+   */
+  public static final RequiredParameter<String> AZURE_BATCH_POOL_ID = new RequiredParameter<>();
+
+  /**
+   * The name of the Azure Storage account.
+   */
+  public static final RequiredParameter<String> AZURE_STORAGE_ACCOUNT_NAME = new RequiredParameter<>();
+
+  /**
+   * The key of the Azure Storage account.
+   */
+  public static final RequiredParameter<String> AZURE_STORAGE_ACCOUNT_KEY = new RequiredParameter<>();
+
+  /**
+   * The name of the Azure Storage account container.
+   */
+  public static final RequiredParameter<String> AZURE_STORAGE_CONTAINER_NAME = new RequiredParameter<>();
+
+  /**
    * The fraction of the container memory NOT to use for the Java Heap.
    */
   public static final OptionalParameter<Double> JVM_HEAP_SLACK = new OptionalParameter<>();
@@ -64,8 +109,17 @@ public class AzureBatchDriverConfiguration extends ConfigurationModuleBuilder {
       .bindImplementation(ResourceLaunchHandler.class, AzureBatchResourceLaunchHandler.class)
       .bindImplementation(ResourceReleaseHandler.class, AzureBatchResourceReleaseHandler.class)
       .bindImplementation(ResourceRequestHandler.class, AzureBatchResourceRequestHandler.class)
-      .bindImplementation(ResourceManagerStartHandler.class, AzureBatchRuntimeStartHandler.class)
-      .bindImplementation(ResourceManagerStopHandler.class, AzureBatchRuntimeStopHandler.class)
+      .bindImplementation(ResourceManagerStartHandler.class, AzureBatchResourceManagerStartHandler.class)
+      .bindImplementation(ResourceManagerStopHandler.class, AzureBatchResourceManagerStopHandler.class)
+
+      // Bind Azure Batch Configuration Parameters
+      .bindNamedParameter(AzureBatchAccountUri.class, AZURE_BATCH_ACCOUNT_URI)
+      .bindNamedParameter(AzureBatchAccountName.class, AZURE_BATCH_ACCOUNT_NAME)
+      .bindNamedParameter(AzureBatchAccountKey.class, AZURE_BATCH_ACCOUNT_KEY)
+      .bindNamedParameter(AzureBatchPoolId.class, AZURE_BATCH_POOL_ID)
+      .bindNamedParameter(AzureStorageAccountName.class, AZURE_STORAGE_ACCOUNT_NAME)
+      .bindNamedParameter(AzureStorageAccountKey.class, AZURE_STORAGE_ACCOUNT_KEY)
+      .bindNamedParameter(AzureStorageAccountContainerName.class, AZURE_STORAGE_CONTAINER_NAME)
 
       // Bind the fields bound in AbstractDriverRuntimeConfiguration
       .bindNamedParameter(JobIdentifier.class, JOB_IDENTIFIER)

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchResourceLaunchHandler.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchResourceLaunchHandler.java
@@ -36,9 +36,8 @@ public final class AzureBatchResourceLaunchHandler implements ResourceLaunchHand
   private final AzureBatchResourceManager azureBatchResourceManager;
 
   @Inject
-  AzureBatchResourceLaunchHandler(AzureBatchResourceManager azureBatchResourceManager) {
+  AzureBatchResourceLaunchHandler(final AzureBatchResourceManager azureBatchResourceManager) {
     this.azureBatchResourceManager = azureBatchResourceManager;
-
   }
 
   @Override

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchResourceLaunchHandler.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchResourceLaunchHandler.java
@@ -18,12 +18,13 @@
  */
 package org.apache.reef.runime.azbatch.driver;
 
-import org.apache.commons.lang.NotImplementedException;
 import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.runtime.common.driver.api.ResourceLaunchEvent;
 import org.apache.reef.runtime.common.driver.api.ResourceLaunchHandler;
 
 import javax.inject.Inject;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * A {@link ResourceLaunchHandler} for Azure Batch.
@@ -31,12 +32,18 @@ import javax.inject.Inject;
 @Private
 public final class AzureBatchResourceLaunchHandler implements ResourceLaunchHandler {
 
+  private static final Logger LOG = Logger.getLogger(AzureBatchResourceLaunchHandler.class.getName());
+  private final AzureBatchResourceManager azureBatchResourceManager;
+
   @Inject
-  AzureBatchResourceLaunchHandler() {
+  AzureBatchResourceLaunchHandler(AzureBatchResourceManager azureBatchResourceManager) {
+    this.azureBatchResourceManager = azureBatchResourceManager;
+
   }
 
   @Override
-  public void onNext(final ResourceLaunchEvent value) {
-    throw new NotImplementedException();
+  public void onNext(final ResourceLaunchEvent resourceLaunchEvent) {
+    LOG.log(Level.FINEST, "Got ResourceLaunchEvent in AzureBatchResourceLaunchHandler");
+    this.azureBatchResourceManager.onResourceLaunched(resourceLaunchEvent);
   }
 }

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchResourceManager.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchResourceManager.java
@@ -121,6 +121,8 @@ public final class AzureBatchResourceManager {
   public void onResourceRequested(ResourceRequestEvent resourceRequestEvent) {
     final String id = UUID.randomUUID().toString();
     final int memorySize = resourceRequestEvent.getMemorySize().get();
+
+    // TODO: Investigate nodeDescriptorHandler usage and remove below dummy node descriptor.
     this.nodeDescriptorHandler.onNext(NodeDescriptorEventImpl.newBuilder()
         .setIdentifier(id)
         .setHostName(this.localAddress)

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchResourceManager.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchResourceManager.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.runime.azbatch.driver;
+
+import com.microsoft.azure.batch.BatchClient;
+import com.microsoft.azure.batch.auth.BatchSharedKeyCredentials;
+import com.microsoft.azure.batch.protocol.models.JobAddParameter;
+import com.microsoft.azure.batch.protocol.models.JobManagerTask;
+import com.microsoft.azure.batch.protocol.models.PoolInformation;
+import com.microsoft.azure.batch.protocol.models.ResourceFile;
+import com.microsoft.windowsazure.storage.StorageException;
+import com.microsoft.windowsazure.storage.blob.BlobProperties;
+import com.microsoft.windowsazure.storage.blob.CloudBlockBlob;
+import org.apache.commons.lang.StringUtils;
+import org.apache.reef.annotations.audience.DriverSide;
+import org.apache.reef.annotations.audience.Private;
+import org.apache.reef.driver.evaluator.EvaluatorProcess;
+import org.apache.reef.runime.azbatch.parameters.AzureBatchAccountKey;
+import org.apache.reef.runime.azbatch.parameters.AzureBatchAccountName;
+import org.apache.reef.runime.azbatch.parameters.AzureBatchAccountUri;
+import org.apache.reef.runime.azbatch.parameters.AzureBatchPoolId;
+import org.apache.reef.runtime.common.driver.api.ResourceLaunchEvent;
+import org.apache.reef.runtime.common.driver.api.ResourceRequestEvent;
+import org.apache.reef.runtime.common.driver.api.RuntimeParameters;
+import org.apache.reef.runtime.common.driver.resourcemanager.NodeDescriptorEvent;
+import org.apache.reef.runtime.common.driver.resourcemanager.NodeDescriptorEventImpl;
+import org.apache.reef.runtime.common.driver.resourcemanager.ResourceAllocationEvent;
+import org.apache.reef.runtime.common.driver.resourcemanager.ResourceEventImpl;
+import org.apache.reef.runtime.common.files.REEFFileNames;
+import org.apache.reef.runtime.common.launch.JavaLaunchCommandBuilder;
+import org.apache.reef.runtime.common.parameters.JVMHeapSlack;
+import org.apache.reef.runtime.hdinsight.client.AzureUploader;
+import org.apache.reef.runtime.hdinsight.client.yarnrest.LocalResource;
+import org.apache.reef.tang.annotations.Parameter;
+import org.apache.reef.tang.exceptions.BindException;
+import org.apache.reef.tang.formats.ConfigurationSerializer;
+import org.apache.reef.util.CollectionUtils;
+import org.apache.reef.wake.EventHandler;
+import org.apache.reef.wake.remote.address.LocalAddressProvider;
+import org.joda.time.DateTime;
+
+import javax.inject.Inject;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * A resource manager that uses threads to execute containers.
+ */
+@Private
+@DriverSide
+public final class AzureBatchResourceManager {
+
+  private static final Logger LOG = Logger.getLogger(AzureBatchResourceManager.class.getName());
+  private final EventHandler<ResourceAllocationEvent> resourceAllocationHandler;
+  private final EventHandler<NodeDescriptorEvent> nodeDescriptorHandler;
+  private String localAddress;
+  private final REEFFileNames fileNames;
+  private final ConfigurationSerializer configurationSerializer;
+  private final double jvmHeapFactor;
+  private final String azureBatchAccountUri;
+  private final String azureBatchAccountName;
+  private final String azureBatchAccountKey;
+  private final String azureBatchPoolId;
+  private final String applicationId;
+  private final AzureUploader azureUploader;
+
+  @Inject
+  AzureBatchResourceManager(
+      @Parameter(RuntimeParameters.ResourceAllocationHandler.class) final EventHandler<ResourceAllocationEvent> resourceAllocationHandler,
+      @Parameter(RuntimeParameters.NodeDescriptorHandler.class) final EventHandler<NodeDescriptorEvent> nodeDescriptorHandler,
+      final LocalAddressProvider localAddressProvider,
+      final REEFFileNames fileNames,
+      final ConfigurationSerializer configurationSerializer,
+      @Parameter(JVMHeapSlack.class) final double jvmHeapSlack,
+      final AzureUploader azureUploader,
+      @Parameter(AzureBatchAccountUri.class) final String azureBatchAccountUri,
+      @Parameter(AzureBatchAccountName.class) final String azureBatchAccountName,
+      @Parameter(AzureBatchAccountKey.class) final String azureBatchAccountKey,
+      @Parameter(AzureBatchPoolId.class) final String azureBatchPoolId) {
+    this.resourceAllocationHandler = resourceAllocationHandler;
+    this.nodeDescriptorHandler = nodeDescriptorHandler;
+    this.localAddress = localAddressProvider.getLocalAddress();
+    this.fileNames = fileNames;
+    this.configurationSerializer = configurationSerializer;
+    this.jvmHeapFactor = 1.0 - jvmHeapSlack;
+    this.azureUploader = azureUploader;
+    this.azureBatchAccountKey = azureBatchAccountKey;
+    this.azureBatchAccountName = azureBatchAccountName;
+    this.azureBatchAccountUri = azureBatchAccountUri;
+    this.azureBatchPoolId = azureBatchPoolId;
+    this.applicationId = "EvaluatorJob-"
+        + this.azureBatchAccountName + "-"
+        + (new Date()).toString()
+        .replace(' ', '-')
+        .replace(':', '-')
+        .replace('.', '-');
+  }
+
+  public void onResourceRequested(ResourceRequestEvent resourceRequestEvent) {
+    final String id = UUID.randomUUID().toString();
+    final int memorySize = resourceRequestEvent.getMemorySize().get();
+    this.nodeDescriptorHandler.onNext(NodeDescriptorEventImpl.newBuilder()
+        .setIdentifier(id)
+        .setHostName(this.localAddress)
+        .setPort(1234)
+        .setMemorySize(memorySize)
+        .build());
+
+    this.resourceAllocationHandler.onNext(ResourceEventImpl.newAllocationBuilder()
+        .setIdentifier(id)
+        .setNodeId(id)
+        .setResourceMemory(memorySize)
+        .setVirtualCores(1)
+        .setRuntimeName(RuntimeIdentifier.RUNTIME_NAME)
+        .build());
+  }
+
+  public void onResourceLaunched(ResourceLaunchEvent resourceLaunchEvent) {
+    // Make the configuration file of the evaluator.
+    final File evaluatorConfigurationFile = new File(this.fileNames.getEvaluatorConfigurationPath());
+    try {
+      this.configurationSerializer.toFile(resourceLaunchEvent.getEvaluatorConf(), evaluatorConfigurationFile);
+    } catch (final IOException | BindException e) {
+      throw new RuntimeException("Unable to write configuration.", e);
+    }
+
+    final List<String> command = getLaunchCommand(resourceLaunchEvent);
+
+    try {
+      LaunchBatchTaskWithConf(evaluatorConfigurationFile, command);
+    } catch (IOException ex) {
+      LOG.log(Level.SEVERE, "Error submitting Azure Batch request", ex);
+      throw new RuntimeException(ex);
+    }
+  }
+
+  private List<String> getLaunchCommand(final ResourceLaunchEvent launchRequest) {
+    // TODO: Rebuild this command using JavaLaunchCommandBuilder
+    return Collections.unmodifiableList(Arrays.asList(
+        "/bin/sh -c \"",
+        "unzip local.jar;",
+        "java -Xmx256m -XX:PermSize=128m -XX:MaxPermSize=128m -classpath local/*:global/*",
+        "-Dproc_reef org.apache.reef.runtime.common.REEFLauncher reef/local/evaluator.conf",
+        "\""
+    ));
+  }
+
+  private void LaunchBatchTaskWithConf(File evaluatorConf, List<String> command) throws IOException {
+    // TODO: Reuse Job Id to submit the task and avoid using JobManagerTask
+    LOG.log(Level.INFO, "onResourceLaunched LaunchBatchTaskWithConf ", StringUtils.join(command, ' '));
+    BatchSharedKeyCredentials cred = new BatchSharedKeyCredentials(
+        this.azureBatchAccountUri, this.azureBatchAccountName, this.azureBatchAccountKey);
+    BatchClient client = BatchClient.open(cred);
+
+    PoolInformation poolInfo = new PoolInformation();
+    poolInfo.withPoolId(this.azureBatchPoolId);
+
+
+    final LocalResource uploadedConfFile = this.azureUploader.uploadFile(evaluatorConf);
+    final ResourceFile confSourceFile = new ResourceFile()
+        .withBlobSource(uploadedConfFile.getUrl())
+        .withFilePath(evaluatorConf.getPath());
+
+    final File localJar = new File("local.jar");
+    final LocalResource jarFile = this.azureUploader.uploadFile(localJar);
+    final ResourceFile jarSourceFile = new ResourceFile()
+        .withBlobSource(jarFile.getUrl())
+        .withFilePath(localJar.getPath());
+
+    List<ResourceFile> resources = new ArrayList<>();
+    resources.add(confSourceFile);
+    resources.add(jarSourceFile);
+
+    JobManagerTask jobManagerTask = new JobManagerTask()
+        .withId(this.applicationId)
+        .withResourceFiles(resources)
+        .withCommandLine(StringUtils.join(command, ' '));
+
+    JobAddParameter jobAddParameter = new JobAddParameter()
+        .withId(this.applicationId)
+        .withJobManagerTask(jobManagerTask)
+        .withPoolInfo(poolInfo);
+
+    client.jobOperations().createJob(jobAddParameter);
+  }
+}

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchResourceManagerStartHandler.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchResourceManagerStartHandler.java
@@ -18,26 +18,26 @@
  */
 package org.apache.reef.runime.azbatch.driver;
 
-import org.apache.reef.runtime.common.driver.api.ResourceManagerStopHandler;
-import org.apache.reef.wake.time.runtime.event.RuntimeStop;
+import org.apache.reef.runtime.common.driver.api.ResourceManagerStartHandler;
+import org.apache.reef.wake.time.runtime.event.RuntimeStart;
 
 import javax.inject.Inject;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Handler of RuntimeStop for the Azure Batch Runtime.
+ * Handler of RuntimeStart for the Azure Batch Runtime.
  */
-public class AzureBatchRuntimeStopHandler implements ResourceManagerStopHandler {
+public class AzureBatchResourceManagerStartHandler implements ResourceManagerStartHandler {
 
-  private static final Logger LOG = Logger.getLogger(AzureBatchRuntimeStopHandler.class.getName());
+  private static final Logger LOG = Logger.getLogger(AzureBatchResourceManagerStartHandler.class.getName());
 
   @Inject
-  AzureBatchRuntimeStopHandler() {
+  AzureBatchResourceManagerStartHandler() {
   }
 
   @Override
-  public void onNext(final RuntimeStop runtimeStop) {
-    LOG.log(Level.FINE, "Azure batch runtime has been stopped...");
+  public void onNext(final RuntimeStart runtimeStart) {
+    LOG.log(Level.FINE, "Azure batch runtime has been started...");
   }
 }

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchResourceManagerStopHandler.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchResourceManagerStopHandler.java
@@ -18,26 +18,26 @@
  */
 package org.apache.reef.runime.azbatch.driver;
 
-import org.apache.reef.runtime.common.driver.api.ResourceManagerStartHandler;
-import org.apache.reef.wake.time.runtime.event.RuntimeStart;
+import org.apache.reef.runtime.common.driver.api.ResourceManagerStopHandler;
+import org.apache.reef.wake.time.runtime.event.RuntimeStop;
 
 import javax.inject.Inject;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Handler of RuntimeStart for the Azure Batch Runtime.
+ * Handler of RuntimeStop for the Azure Batch Runtime.
  */
-public class AzureBatchRuntimeStartHandler implements ResourceManagerStartHandler {
+public class AzureBatchResourceManagerStopHandler implements ResourceManagerStopHandler {
 
-  private static final Logger LOG = Logger.getLogger(AzureBatchRuntimeStartHandler.class.getName());
+  private static final Logger LOG = Logger.getLogger(AzureBatchResourceManagerStopHandler.class.getName());
 
   @Inject
-  AzureBatchRuntimeStartHandler() {
+  AzureBatchResourceManagerStopHandler() {
   }
 
   @Override
-  public void onNext(final RuntimeStart runtimeStart) {
-    LOG.log(Level.FINE, "Azure batch runtime has been started...");
+  public void onNext(final RuntimeStop runtimeStop) {
+    LOG.log(Level.FINE, "Azure batch runtime has been stopped...");
   }
 }

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchResourceReleaseHandler.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchResourceReleaseHandler.java
@@ -18,12 +18,13 @@
  */
 package org.apache.reef.runime.azbatch.driver;
 
-import org.apache.commons.lang.NotImplementedException;
 import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.runtime.common.driver.api.ResourceReleaseEvent;
 import org.apache.reef.runtime.common.driver.api.ResourceReleaseHandler;
 
 import javax.inject.Inject;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * A {@link ResourceReleaseHandler} for Azure Batch.
@@ -31,12 +32,14 @@ import javax.inject.Inject;
 @Private
 public class AzureBatchResourceReleaseHandler implements ResourceReleaseHandler {
 
+  private static final Logger LOG = Logger.getLogger(AzureBatchResourceLaunchHandler.class.getName());
+
   @Inject
   AzureBatchResourceReleaseHandler() {
   }
 
   @Override
   public void onNext(final ResourceReleaseEvent value) {
-    throw new NotImplementedException();
+    LOG.log(Level.FINEST, "Got ResourceReleaseEvent in AzureBatchResourceLaunchHandler");
   }
 }

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchResourceRequestHandler.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchResourceRequestHandler.java
@@ -26,7 +26,6 @@ import javax.inject.Inject;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-
 /**
  * A {@link ResourceRequestHandler} for Azure Batch.
  */

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchResourceRequestHandler.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/driver/AzureBatchResourceRequestHandler.java
@@ -18,12 +18,14 @@
  */
 package org.apache.reef.runime.azbatch.driver;
 
-import org.apache.commons.lang.NotImplementedException;
 import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.runtime.common.driver.api.ResourceRequestEvent;
 import org.apache.reef.runtime.common.driver.api.ResourceRequestHandler;
 
 import javax.inject.Inject;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 
 /**
  * A {@link ResourceRequestHandler} for Azure Batch.
@@ -31,12 +33,18 @@ import javax.inject.Inject;
 @Private
 public class AzureBatchResourceRequestHandler implements ResourceRequestHandler {
 
+  private static final Logger LOG = Logger.getLogger(AzureBatchResourceLaunchHandler.class.getName());
+  private final AzureBatchResourceManager azureBatchResourceManager;
+
   @Inject
-  AzureBatchResourceRequestHandler() {
+  AzureBatchResourceRequestHandler(final AzureBatchResourceManager azureBatchResourceManager) {
+    this.azureBatchResourceManager = azureBatchResourceManager;
   }
 
   @Override
-  public void onNext(final ResourceRequestEvent value) {
-    throw new NotImplementedException();
+  public void onNext(final ResourceRequestEvent resourceRequestEvent) {
+    LOG.log(Level.FINEST, "Got ResourceRequestEvent in AzureBatchResourceRequestHandler: memory = {0}, cores = {1}.",
+        new Object[]{resourceRequestEvent.getMemorySize(), resourceRequestEvent.getVirtualCores()});
+    this.azureBatchResourceManager.onResourceRequested(resourceRequestEvent);
   }
 }


### PR DESCRIPTION
Add Runtime Start/Stop Handler and Resource Release/Request/Launch Handler. Submit Evaluator task to AzureBatch.

This patch is going submit the evaluator task to Azure Batch from Driver Runtime. "Hello Reef" will be printed in stdout.txt in evaluator task node.

Please note:
1. AzureBatch credential is still hard coded in DriverConfiguration. This should be eventually provided by client code. Mentioned in TODO.

2. Evaluator Java commandline is hard coded now. It should be configurable. 

3. We need to figure out how to pass through Job Id, so we don't need to create a new Job for submitting evaluator task.

4. We need to investigate "NodeDescriptorHandler" use for evaluator. As Batch concept, this node is not needed but it is required by evaluator. TODO: replace the dummy setup.