### PR TITLE
org.apache.reef.util.OSUtils getPID fails running on AzureBatch Windows Pool

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/OSUtils.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/OSUtils.java
@@ -77,6 +77,7 @@ public final class OSUtils {
         final Process process = new ProcessBuilder()
             .command("bash", "-c", "echo $PPID")
             .start();
+        // Fix Reef-1977
         process.waitFor();
 
         final byte[] returnBytes = new byte[128];
@@ -96,6 +97,7 @@ public final class OSUtils {
             .command("powershell.exe", "-NoProfile", "-Command",
                 "wmic process where processid=$pid get parentprocessid")
             .start();
+        // Fix Reef-1977
         process.waitFor();
 
         final byte[] returnBytes = new byte[128];

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/OSUtils.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/OSUtils.java
@@ -20,7 +20,6 @@ package org.apache.reef.util;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/OSUtils.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/OSUtils.java
@@ -20,6 +20,7 @@ package org.apache.reef.util;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -77,6 +78,8 @@ public final class OSUtils {
         final Process process = new ProcessBuilder()
             .command("bash", "-c", "echo $PPID")
             .start();
+        process.waitFor();
+
         final byte[] returnBytes = new byte[128];
         if (process.getInputStream().read(returnBytes) == -1) {
           LOG.log(Level.FINE, "No data read because end of stream was reached");
@@ -94,6 +97,8 @@ public final class OSUtils {
             .command("powershell.exe", "-NoProfile", "-Command",
                 "wmic process where processid=$pid get parentprocessid")
             .start();
+        process.waitFor();
+
         final byte[] returnBytes = new byte[128];
         if (process.getInputStream().read(returnBytes) == -1) {
           LOG.log(Level.FINE, "No data read because end of stream was reached");


### PR DESCRIPTION
OSUtils.getPID() should read Process execution result after it is completed

using Process.waitFor() instead of public Process.waitFor(long timeout, TimeUnit unit) to make sure it is compatible with Java 1.7+

I will create a JIRA ticket as well since this bug exists not just in Azbatch