### PR TITLE
Allow running in single node pool

### DIFF
--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/client/AzureBatchJobSubmissionHelper.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runime/azbatch/client/AzureBatchJobSubmissionHelper.java
@@ -70,6 +70,7 @@ public class AzureBatchJobSubmissionHelper implements AutoCloseable {
         .withFilePath(AzureBatchFileNames.TASK_JAR_FILE_NAME);
 
     JobManagerTask jobManagerTask = new JobManagerTask()
+        .withRunExclusive(false)
         .withId(applicationId)
         .withResourceFiles(Collections.singletonList(jarResourceFile))
         .withCommandLine(command);


### PR DESCRIPTION
By default, JobManagerTask is running exclusively in one node, which blocks other task to run on the same node.

Disable this property will allow the node running multiple concurrent tasks.

See:
https://docs.microsoft.com/en-us/java/api/com.microsoft.azure.batch.protocol.models._job_manager_task.withrunexclusive#com_microsoft_azure_batch_protocol_models__job_manager_task_withRunExclusive_Boolean_