### PR TITLE
Seperate shim.conf and jars dependency and fix alarm scheduling

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/REEFFileNames.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/REEFFileNames.java
@@ -27,7 +27,7 @@ import java.io.File;
  * Access to the various places things go according to the REEF file system standard.
  */
 @Immutable
-public class REEFFileNames {
+public final class REEFFileNames {
 
   private static final String REEF_BASE_FOLDER = "reef";
   private static final String GLOBAL_FOLDER = "global";

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/REEFFileNames.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/REEFFileNames.java
@@ -27,7 +27,7 @@ import java.io.File;
  * Access to the various places things go according to the REEF file system standard.
  */
 @Immutable
-public final class REEFFileNames {
+public class REEFFileNames {
 
   private static final String REEF_BASE_FOLDER = "reef";
   private static final String GLOBAL_FOLDER = "global";

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runtime/azbatch/driver/AzureBatchEvaluatorShimManager.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runtime/azbatch/driver/AzureBatchEvaluatorShimManager.java
@@ -288,7 +288,7 @@ public final class AzureBatchEvaluatorShimManager
 
   private void createAzureBatchTask(final String taskId, final URI jarFileUri) throws IOException {
     final Configuration shimConfig = this.evaluatorShimConfigurationProvider.getConfiguration(taskId);
-    final File shim = new File(this.azureBatchFileNames.getLocalFolderPath(), this.azureBatchFileNames.getEvaluatorShimConfigurationName() + taskId);
+    final File shim = new File(this.azureBatchFileNames.getLocalFolderPath(), taskId + '-' + this.azureBatchFileNames.getEvaluatorShimConfigurationName());
     this.configurationSerializer.toFile(shimConfig, shim);
     final URI shimUri = this.uploadFile(shim);
     this.azureBatchHelper.submitTask(getAzureBatchJobId(), taskId, jarFileUri, shimUri, getEvaluatorShimLaunchCommand());

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runtime/azbatch/driver/AzureBatchEvaluatorShimManager.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runtime/azbatch/driver/AzureBatchEvaluatorShimManager.java
@@ -135,7 +135,8 @@ public final class AzureBatchEvaluatorShimManager
     }
   }
 
-  public void onResourceRequested(final String containerId, final ResourceRequestEvent resourceRequestEvent, final URI jarFileUri) {
+  public void onResourceRequested(final String containerId, final ResourceRequestEvent resourceRequestEvent,
+                                  final URI jarFileUri) {
     try {
       createAzureBatchTask(containerId, jarFileUri);
       this.outstandingResourceRequests.put(containerId, resourceRequestEvent);
@@ -279,6 +280,10 @@ public final class AzureBatchEvaluatorShimManager
         this.azureBatchFileNames.getEvaluatorShimConfigurationPath());
   }
 
+  /**
+   * @return The name under which the evaluator shim configuration will be stored in
+   * REEF_BASE_FOLDER/LOCAL_FOLDER.
+   */
   private FileResource getFileResourceFromFile(final File configFile, final FileType type) {
     return FileResourceImpl.newBuilder()
         .setName(configFile.getName())
@@ -288,10 +293,12 @@ public final class AzureBatchEvaluatorShimManager
 
   private void createAzureBatchTask(final String taskId, final URI jarFileUri) throws IOException {
     final Configuration shimConfig = this.evaluatorShimConfigurationProvider.getConfiguration(taskId);
-    final File shim = new File(this.azureBatchFileNames.getLocalFolderPath(), taskId + '-' + this.azureBatchFileNames.getEvaluatorShimConfigurationName());
+    final File shim = new File(this.reefFileNames.getLocalFolderPath(),
+        taskId + '-' + this.azureBatchFileNames.getEvaluatorShimConfigurationName());
     this.configurationSerializer.toFile(shimConfig, shim);
     final URI shimUri = this.uploadFile(shim);
-    this.azureBatchHelper.submitTask(getAzureBatchJobId(), taskId, jarFileUri, shimUri, getEvaluatorShimLaunchCommand());
+    this.azureBatchHelper.submitTask(getAzureBatchJobId(), taskId, jarFileUri,
+        shimUri, getEvaluatorShimLaunchCommand());
   }
 
   private File writeFileResourcesJarFile(final Set<FileResource> fileResourceSet) throws IOException {
@@ -300,7 +307,7 @@ public final class AzureBatchEvaluatorShimManager
 
   private URI uploadFile(final File jarFile) throws IOException {
     final String folderName = this.azureBatchFileNames.getStorageJobFolder(this.getAzureBatchJobId());
-    LOG.log(Level.FINE, "Uploading {0} to {0}.", new Object[]{jarFile.getAbsolutePath(), folderName});
+    LOG.log(Level.FINE, "Uploading {0} to {1}.", new Object[]{jarFile.getAbsolutePath(), folderName});
     return this.azureStorageUtil.uploadFile(folderName, jarFile);
   }
 

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runtime/azbatch/driver/AzureBatchEvaluatorShimManager.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runtime/azbatch/driver/AzureBatchEvaluatorShimManager.java
@@ -18,15 +18,10 @@
  */
 package org.apache.reef.runtime.azbatch.driver;
 
-import com.sun.jndi.toolkit.url.Uri;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.proto.EvaluatorShimProtocol;
-import org.apache.reef.runtime.azbatch.util.AzureBatchFileNames;
-import org.apache.reef.runtime.azbatch.util.AzureBatchHelper;
-import org.apache.reef.runtime.azbatch.util.AzureStorageUtil;
-import org.apache.reef.runtime.azbatch.util.CommandBuilder;
-import org.apache.reef.runtime.azbatch.util.RemoteIdentifierParser;
+import org.apache.reef.runtime.azbatch.util.*;
 import org.apache.reef.runtime.common.driver.api.ResourceLaunchEvent;
 import org.apache.reef.runtime.common.driver.api.ResourceReleaseEvent;
 import org.apache.reef.runtime.common.driver.api.ResourceRequestEvent;
@@ -35,16 +30,16 @@ import org.apache.reef.runtime.common.driver.resourcemanager.NodeDescriptorEvent
 import org.apache.reef.runtime.common.driver.resourcemanager.ResourceEventImpl;
 import org.apache.reef.runtime.common.driver.resourcemanager.RuntimeStatusEventImpl;
 import org.apache.reef.runtime.common.files.*;
-import org.apache.reef.tang.Configuration;
-import org.apache.reef.wake.EventHandler;
 import org.apache.reef.runtime.common.utils.RemoteManager;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.formats.ConfigurationSerializer;
+import org.apache.reef.wake.EventHandler;
 import org.apache.reef.wake.remote.RemoteMessage;
 
 import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URL;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
@@ -64,7 +59,6 @@ public final class AzureBatchEvaluatorShimManager
   private static final Logger LOG = Logger.getLogger(AzureBatchEvaluatorShimManager.class.getName());
 
   private static final String AZ_BATCH_JOB_ID_ENV = "AZ_BATCH_JOB_ID";
-  private static final String AZ_BATCH_TASK_ID_ENV = "AZ_BATCH_TASK_ID";
   private static final int EVALUATOR_SHIM_MEMORY_MB = 64;
 
   private final Map<String, ResourceRequestEvent> outstandingResourceRequests;
@@ -80,8 +74,8 @@ public final class AzureBatchEvaluatorShimManager
   private final AzureBatchEvaluatorShimConfigurationProvider evaluatorShimConfigurationProvider;
   private final JobJarMaker jobJarMaker;
   private final CommandBuilder launchCommandBuilder;
-
   private final REEFEventHandlers reefEventHandlers;
+  private final ConfigurationSerializer configurationSerializer;
 
   @Inject
   AzureBatchEvaluatorShimManager(
@@ -93,7 +87,8 @@ public final class AzureBatchEvaluatorShimManager
       final CommandBuilder launchCommandBuilder,
       final AzureBatchHelper azureBatchHelper,
       final JobJarMaker jobJarMaker,
-      final AzureBatchEvaluatorShimConfigurationProvider evaluatorShimConfigurationProvider) {
+      final AzureBatchEvaluatorShimConfigurationProvider evaluatorShimConfigurationProvider,
+      final ConfigurationSerializer configurationSerializer) {
     this.azureStorageUtil = azureStorageUtil;
     this.reefFileNames = reefFileNames;
     this.azureBatchFileNames = azureBatchFileNames;
@@ -113,28 +108,24 @@ public final class AzureBatchEvaluatorShimManager
 
     this.evaluatorShimCommandChannel = remoteManager
         .registerHandler(EvaluatorShimProtocol.EvaluatorShimStatusProto.class, this);
+
+    this.configurationSerializer = configurationSerializer;
   }
 
   public URI generateShimJarFile() {
-    LOG.log(Level.INFO, "generateShimJarFile");
-    try {
-      final Configuration shimConfig = this.evaluatorShimConfigurationProvider.getConfiguration(getAzureBatchTaskId());
 
-      Set<FileResource> localFiles = new HashSet<>();
+    try {
       Set<FileResource> globalFiles = new HashSet<>();
 
       final File globalFolder = new File(this.reefFileNames.getGlobalFolderPath());
-
       final File[] filesInGlobalFolder = globalFolder.listFiles();
+
       for (final File fileEntry : filesInGlobalFolder != null ? filesInGlobalFolder : new File[]{}) {
         globalFiles.add(getFileResourceFromFile(fileEntry, FileType.LIB));
       }
 
       File jarFile = this.jobJarMaker.newBuilder()
-          .withConfiguration(shimConfig)
           .withGlobalFileSet(globalFiles)
-          .withLocalFileSet(localFiles)
-          .withConfigurationFileName(this.azureBatchFileNames.getEvaluatorShimConfigurationName())
           .build();
 
       return uploadFile(jarFile);
@@ -143,7 +134,6 @@ public final class AzureBatchEvaluatorShimManager
       throw new RuntimeException(ex);
     }
   }
-
 
   public void onResourceRequested(final String containerId, final ResourceRequestEvent resourceRequestEvent, final URI jarFileUri) {
     try {
@@ -297,7 +287,11 @@ public final class AzureBatchEvaluatorShimManager
   }
 
   private void createAzureBatchTask(final String taskId, final URI jarFileUri) throws IOException {
-    this.azureBatchHelper.submitTask(getAzureBatchJobId(), taskId, jarFileUri, getEvaluatorShimLaunchCommand());
+    final Configuration shimConfig = this.evaluatorShimConfigurationProvider.getConfiguration(taskId);
+    final File shim = new File(this.azureBatchFileNames.getLocalFolderPath(), this.azureBatchFileNames.getEvaluatorShimConfigurationName());
+    this.configurationSerializer.toFile(shimConfig, shim);
+    final URI shimUri = this.uploadFile(shim);
+    this.azureBatchHelper.submitTask(getAzureBatchJobId(), taskId, jarFileUri, shimUri, getEvaluatorShimLaunchCommand());
   }
 
   private File writeFileResourcesJarFile(final Set<FileResource> fileResourceSet) throws IOException {
@@ -312,9 +306,5 @@ public final class AzureBatchEvaluatorShimManager
 
   private String getAzureBatchJobId() {
     return System.getenv(AZ_BATCH_JOB_ID_ENV);
-  }
-
-  private String getAzureBatchTaskId() {
-    return System.getenv(AZ_BATCH_TASK_ID_ENV);
   }
 }

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runtime/azbatch/driver/AzureBatchResourceManager.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runtime/azbatch/driver/AzureBatchResourceManager.java
@@ -29,7 +29,6 @@ import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.tang.formats.ConfigurationSerializer;
 
 import javax.inject.Inject;
-import java.io.File;
 import java.net.URI;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runtime/azbatch/driver/AzureBatchResourceManager.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runtime/azbatch/driver/AzureBatchResourceManager.java
@@ -73,11 +73,11 @@ public final class AzureBatchResourceManager {
   }
 
   public void onResourceRequested(final ResourceRequestEvent resourceRequestEvent) {
-    LOG.log(Level.INFO, "Got ResourceRequestEvent in AzureBatchResourceManager,");
+    LOG.log(Level.FINEST, "Got ResourceRequestEvent in AzureBatchResourceManager,");
     URI jarFileUri = this.evaluatorShimManager.generateShimJarFile();
     for (int r = 0; r < resourceRequestEvent.getResourceCount(); r++) {
       final String containerId = generateContainerId();
-      LOG.log(Level.INFO, "containerId in AzureBatchResourceManager {0}", containerId);
+      LOG.log(Level.FINE, "containerId in AzureBatchResourceManager {0}", containerId);
       this.containerRequests.put(containerId, resourceRequestEvent);
       this.containerCount.incrementAndGet();
       this.evaluatorShimManager.onResourceRequested(containerId, resourceRequestEvent, jarFileUri);

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runtime/azbatch/driver/AzureBatchResourceManager.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runtime/azbatch/driver/AzureBatchResourceManager.java
@@ -29,6 +29,8 @@ import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.tang.formats.ConfigurationSerializer;
 
 import javax.inject.Inject;
+import java.io.File;
+import java.net.URI;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -72,13 +74,14 @@ public final class AzureBatchResourceManager {
   }
 
   public void onResourceRequested(final ResourceRequestEvent resourceRequestEvent) {
-    LOG.log(Level.FINEST, "Got ResourceRequestEvent in AzureBatchResourceManager,");
+    LOG.log(Level.INFO, "Got ResourceRequestEvent in AzureBatchResourceManager,");
+    URI jarFileUri = this.evaluatorShimManager.generateShimJarFile();
     for (int r = 0; r < resourceRequestEvent.getResourceCount(); r++) {
       final String containerId = generateContainerId();
       this.containerRequests.put(containerId, resourceRequestEvent);
       this.containerCount.incrementAndGet();
       this.azureBatchTaskStatusAlarmHandler.enableAlarm();
-      this.evaluatorShimManager.onResourceRequested(containerId, resourceRequestEvent);
+      this.evaluatorShimManager.onResourceRequested(containerId, resourceRequestEvent, jarFileUri);
     }
   }
 

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runtime/azbatch/driver/AzureBatchResourceManager.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runtime/azbatch/driver/AzureBatchResourceManager.java
@@ -29,7 +29,6 @@ import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.tang.formats.ConfigurationSerializer;
 
 import javax.inject.Inject;
-import java.io.File;
 import java.net.URI;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -78,10 +77,15 @@ public final class AzureBatchResourceManager {
     URI jarFileUri = this.evaluatorShimManager.generateShimJarFile();
     for (int r = 0; r < resourceRequestEvent.getResourceCount(); r++) {
       final String containerId = generateContainerId();
+      LOG.log(Level.INFO, "containerId in AzureBatchResourceManager {0}", containerId);
       this.containerRequests.put(containerId, resourceRequestEvent);
       this.containerCount.incrementAndGet();
-      this.azureBatchTaskStatusAlarmHandler.enableAlarm();
       this.evaluatorShimManager.onResourceRequested(containerId, resourceRequestEvent, jarFileUri);
+    }
+
+    int currentContainerCount = this.containerCount.decrementAndGet();
+    if (currentContainerCount > 0) {
+      this.azureBatchTaskStatusAlarmHandler.enableAlarm();
     }
   }
 

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runtime/azbatch/driver/AzureBatchResourceManager.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runtime/azbatch/driver/AzureBatchResourceManager.java
@@ -83,7 +83,7 @@ public final class AzureBatchResourceManager {
       this.evaluatorShimManager.onResourceRequested(containerId, resourceRequestEvent, jarFileUri);
     }
 
-    int currentContainerCount = this.containerCount.decrementAndGet();
+    int currentContainerCount = this.containerCount.get();
     if (currentContainerCount > 0) {
       this.azureBatchTaskStatusAlarmHandler.enableAlarm();
     }

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runtime/azbatch/driver/AzureBatchTaskStatusAlarmHandler.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runtime/azbatch/driver/AzureBatchTaskStatusAlarmHandler.java
@@ -109,8 +109,12 @@ final class AzureBatchTaskStatusAlarmHandler implements EventHandler<Alarm> {
    * Enable the period alarm to send status updates.
    */
   public synchronized void enableAlarm() {
-    this.isAlarmEnabled = true;
-    this.scheduleAlarm();
+    if (!this.isAlarmEnabled) {
+      this.isAlarmEnabled = true;
+      this.scheduleAlarm();
+    } else {
+      LOG.log(Level.FINE, "Alarm is already scheduled.");
+    }
   }
 
   /**

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runtime/azbatch/util/AzureBatchFileNames.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runtime/azbatch/util/AzureBatchFileNames.java
@@ -27,7 +27,7 @@ import javax.inject.Inject;
  * Access to the various places things go according to the REEF Azure Batch runtime.
  */
 @Private
-public final class AzureBatchFileNames {
+public final class AzureBatchFileNames extends REEFFileNames {
 
   private static final String STORAGE_JOB_FOLDER_PATH = "apps/reef/jobs/";
   private static final String TASK_JAR_FILE_NAME = "local.jar";

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runtime/azbatch/util/AzureBatchFileNames.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runtime/azbatch/util/AzureBatchFileNames.java
@@ -27,7 +27,7 @@ import javax.inject.Inject;
  * Access to the various places things go according to the REEF Azure Batch runtime.
  */
 @Private
-public final class AzureBatchFileNames extends REEFFileNames {
+public final class AzureBatchFileNames {
 
   private static final String STORAGE_JOB_FOLDER_PATH = "apps/reef/jobs/";
   private static final String TASK_JAR_FILE_NAME = "local.jar";
@@ -80,7 +80,6 @@ public final class AzureBatchFileNames extends REEFFileNames {
   }
 
   /**
-   * @return The name under which the evaluator shim configuration will be stored in REEF_BASE_FOLDER/LOCAL_FOLDER.
    * @return
    */
   public String getEvaluatorShimConfigurationName() {

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runtime/azbatch/util/AzureBatchHelper.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runtime/azbatch/util/AzureBatchHelper.java
@@ -45,8 +45,6 @@ public class AzureBatchHelper {
 
   private static final Logger LOG = Logger.getLogger(AzureBatchJobSubmissionHandler.class.getName());
 
-  private final AzureBatchFileNames azureBatchFileNames;
-
   /*
    * Environment variable that contains the Azure Batch jobId.
    */
@@ -61,12 +59,10 @@ public class AzureBatchHelper {
 
   @Inject
   public AzureBatchHelper(
-      final AzureBatchFileNames azureBatchFileNames,
       @Parameter(AzureBatchAccountUri.class) final String azureBatchAccountUri,
       @Parameter(AzureBatchAccountName.class) final String azureBatchAccountName,
       @Parameter(AzureBatchAccountKey.class) final String azureBatchAccountKey,
       @Parameter(AzureBatchPoolId.class) final String azureBatchPoolId) {
-    this.azureBatchFileNames = azureBatchFileNames;
     this.azureBatchAccountUri = azureBatchAccountUri;
     this.azureBatchAccountName = azureBatchAccountName;
     this.azureBatchAccountKey = azureBatchAccountKey;
@@ -91,7 +87,7 @@ public class AzureBatchHelper {
   public void submitJob(final String applicationId, final URI jobJarUri, final String command) throws IOException {
     ResourceFile jarResourceFile = new ResourceFile()
         .withBlobSource(jobJarUri.toString())
-        .withFilePath(this.azureBatchFileNames.getTaskJarFileName());
+        .withFilePath(AzureBatchFileNames.getTaskJarFileName());
 
     JobManagerTask jobManagerTask = new JobManagerTask()
         .withRunExclusive(false)
@@ -123,7 +119,7 @@ public class AzureBatchHelper {
 
     final ResourceFile jarSourceFile = new ResourceFile()
         .withBlobSource(jobJarUri.toString())
-        .withFilePath(this.azureBatchFileNames.getTaskJarFileName());
+        .withFilePath(AzureBatchFileNames.getTaskJarFileName());
 
     final List<ResourceFile> resources = new ArrayList<>();
     resources.add(jarSourceFile);

--- a/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runtime/azbatch/util/LinuxCommandBuilder.java
+++ b/lang/java/reef-runtime-azbatch/src/main/java/org/apache/reef/runtime/azbatch/util/LinuxCommandBuilder.java
@@ -39,7 +39,7 @@ public class LinuxCommandBuilder extends AbstractCommandBuilder {
   private static final Class SHIM_LAUNCHER_CLASS = EvaluatorShimLauncher.class;
   private static final List<String> COMMAND_LIST_PREFIX =
       Collections.unmodifiableList(Arrays.asList(
-          "ln -sfn '.' 'reef';", "unzip " + AzureBatchFileNames.getTaskJarFileName() + ";"));
+          "unzip " + AzureBatchFileNames.getTaskJarFileName() + " -d 'reef/'" + ";"));
   private static final char CLASSPATH_SEPARATOR_CHAR = ':';
   private static final String OS_COMMAND_FORMAT = "/bin/sh -c \"%s\"";
 

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/AzureBatchTestEnvironment.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/AzureBatchTestEnvironment.java
@@ -63,7 +63,7 @@ public final class AzureBatchTestEnvironment extends TestEnvironmentBase impleme
 
   @Override
   public int getTestTimeout() {
-    return 60000; // 1 min.
+    return 5 * 60000; // 5 min.
   }
 
   @Override


### PR DESCRIPTION
1. Seperate shim.conf and jars dependency.
2. Reduce the alarm spamming messages.
3. Change the timeout value to 5 min to match up YARN setup.
4. Remove soft link in LinuxCommand Builder, as it will throw error if "reef" directory exists, even with "sfn" option set.
5. Fix an exception when Shim is trying to create a directory when extracting files.

With this change, the performance of CloseEvaluatorTest (16 evaluators) improves from 5 min + to 78 seconds.