### PR TITLE
Add AzureBatch runtime support in reef-bridge-client and reef-bridge-java

### DIFF
--- a/lang/java/reef-bridge-client/pom.xml
+++ b/lang/java/reef-bridge-client/pom.xml
@@ -56,7 +56,7 @@ under the License.
             <artifactId>reef-runtime-hdinsight</artifactId>
             <version>${project.version}</version>
         </dependency>
-		<dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>reef-runtime-azbatch</artifactId>
             <version>${project.version}</version>

--- a/lang/java/reef-bridge-client/pom.xml
+++ b/lang/java/reef-bridge-client/pom.xml
@@ -56,6 +56,11 @@ under the License.
             <artifactId>reef-runtime-hdinsight</artifactId>
             <version>${project.version}</version>
         </dependency>
+		<dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>reef-runtime-azbatch</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>reef-io</artifactId>

--- a/lang/java/reef-bridge-java/pom.xml
+++ b/lang/java/reef-bridge-java/pom.xml
@@ -51,7 +51,7 @@ under the License.
             <artifactId>reef-runtime-yarn</artifactId>
             <version>${project.version}</version>
         </dependency>
-	    <dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>reef-runtime-azbatch</artifactId>
             <version>${project.version}</version>

--- a/lang/java/reef-bridge-java/pom.xml
+++ b/lang/java/reef-bridge-java/pom.xml
@@ -51,6 +51,11 @@ under the License.
             <artifactId>reef-runtime-yarn</artifactId>
             <version>${project.version}</version>
         </dependency>
+	    <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>reef-runtime-azbatch</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>reef-io</artifactId>


### PR DESCRIPTION
This is for REEF .NET not Java. .NET build will recompile reef-bridge-client and reef-bridge-java using maven and java.