### PR TITLE
Add reef-bridge-client.jar to global folder in azure batch

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client/AzureBatch/Storage/AzureStorageUploader.cs
+++ b/lang/cs/Org.Apache.REEF.Client/AzureBatch/Storage/AzureStorageUploader.cs
@@ -70,7 +70,7 @@ namespace Org.Apache.REEF.Client.AzureBatch.Storage
             string sas = blob.GetSharedAccessSignature(CreateSASPolicy());
             string uri = blob.Uri.AbsoluteUri;
             Uri uploadedFile = new Uri(uri + sas);
-            LOGGER.Log(Level.Info, "Uploaded {0} jar file to {1}", new String[] { filePath, uploadedFile.ToString() });
+            LOGGER.Log(Level.Info, "Uploaded {0} jar file to {1}", new string[] { filePath, uploadedFile.ToString() });
             return uploadedFile;
         }
 

--- a/lang/cs/Org.Apache.REEF.Client/AzureBatch/Util/JobJarMaker.cs
+++ b/lang/cs/Org.Apache.REEF.Client/AzureBatch/Util/JobJarMaker.cs
@@ -78,7 +78,7 @@ namespace Org.Apache.REEF.Client.AzureBatch.Util
             };
             _avroAzureBatchJobSubmissionParameters.sharedJobSubmissionParameters = bootstrapJobArgs;
             string localDriverFolderPath = CreateDriverFolder(jobRequest.JobIdentifier);
-            _driverFolderPreparationHelper.PrepareDriverFolder(jobRequest.AppParameters, localDriverFolderPath);
+            _driverFolderPreparationHelper.PrepareDriverFolderWithGlobalBridgeJar(jobRequest.AppParameters, localDriverFolderPath);
             _paramSerializer.SerializeJobFile(localDriverFolderPath, _avroAzureBatchJobSubmissionParameters);
 
             return _resourceArchiveFileGenerator.CreateArchiveToUpload(localDriverFolderPath);

--- a/lang/cs/Org.Apache.REEF.Client/Common/DriverFolderPreparationHelper.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Common/DriverFolderPreparationHelper.cs
@@ -82,26 +82,12 @@ namespace Org.Apache.REEF.Client.Common
         /// <param name="driverFolderPath"></param>
         internal void PrepareDriverFolder(AppParameters appParameters, string driverFolderPath)
         {
-            Logger.Log(Level.Info, "Preparing Driver filesystem layout in {0}", driverFolderPath);
+            InternalPrepareDriverFolderInLocal(appParameters, driverFolderPath, true);
+        }
 
-            // Setup the folder structure
-            CreateDefaultFolderStructure(appParameters, driverFolderPath);
-
-            // Add the appParameters into that folder structure
-            _fileSets.AddJobFiles(appParameters);
-
-            // Add the reef-bridge-client jar to the global files in the manner of JavaClientLauncher.cs.
-            _fileSets.AddToLocalFiles(Directory.GetFiles(JarFolder)
-                .Where(file => !string.IsNullOrWhiteSpace(file))
-                .Where(jarFile => Path.GetFileName(jarFile).ToLower().StartsWith(ClientConstants.ClientJarFilePrefix)));
-
-            // Create the driver configuration
-            CreateDriverConfiguration(appParameters, driverFolderPath);
-
-            // Initiate the final copy
-            _fileSets.CopyToDriverFolder(driverFolderPath);
-
-            Logger.Log(Level.Info, "Done preparing Driver filesystem layout in {0}", driverFolderPath);
+        internal void PrepareDriverFolderWithGlobalBridgeJar(AppParameters appParameters, string driverFolderPath)
+        {
+            InternalPrepareDriverFolderInLocal(appParameters, driverFolderPath, false);
         }
 
         /// <summary>
@@ -144,7 +130,7 @@ namespace Org.Apache.REEF.Client.Common
                     File.WriteAllBytes(fileName, resourceHelper.GetBytes(fileResources.Value));
                 }
             }
-            
+
             // generate .config file for bridge executable
             var config = DefaultDriverConfigurationFileContents;
             if (!string.IsNullOrEmpty(appParameters.DriverConfigurationFileContents))
@@ -164,6 +150,40 @@ namespace Org.Apache.REEF.Client.Common
             }
             Logger.Log(Level.Verbose, "Create EvaluatorConfigFile {0} with config {1}.", evaluatorConfigFilName, evaluatorAppConfigString);
             File.WriteAllText(evaluatorConfigFilName, evaluatorAppConfigString);
+        }
+
+        private void InternalPrepareDriverFolderInLocal(AppParameters appParameters, string driverFolderPath, bool bridgeJarInLocal)
+        {
+            Logger.Log(Level.Info, "Preparing Driver filesystem layout in {0}", driverFolderPath);
+
+            // Setup the folder structure
+            CreateDefaultFolderStructure(appParameters, driverFolderPath);
+
+            // Add the appParameters into that folder structure
+            _fileSets.AddJobFiles(appParameters);
+
+            if (bridgeJarInLocal)
+            {
+                // Add the reef-bridge-client jar to the local files in the manner of JavaClientLauncher.cs.
+                _fileSets.AddToLocalFiles(Directory.GetFiles(JarFolder)
+                    .Where(file => !string.IsNullOrWhiteSpace(file))
+                    .Where(jarFile => Path.GetFileName(jarFile).ToLower().StartsWith(ClientConstants.ClientJarFilePrefix)));
+            }
+            else
+            {
+                // Add the reef-bridge-client jar to the global files in the manner of JavaClientLauncher.cs.
+                _fileSets.AddToGlobalFiles(Directory.GetFiles(JarFolder)
+                    .Where(file => !string.IsNullOrWhiteSpace(file))
+                    .Where(jarFile => Path.GetFileName(jarFile).ToLower().StartsWith(ClientConstants.ClientJarFilePrefix)));
+            }
+
+            // Create the driver configuration
+            CreateDriverConfiguration(appParameters, driverFolderPath);
+
+            // Initiate the final copy
+            _fileSets.CopyToDriverFolder(driverFolderPath);
+
+            Logger.Log(Level.Info, "Done preparing Driver filesystem layout in {0}", driverFolderPath);
         }
     }
 }


### PR DESCRIPTION
This PR is on top of my previous PR. The idea behind this is that in .NET implementation, reef-bridge-client.jar is added to local directory not global directory. For other runtime,  reef-bridge-client.jar is only needed by Driver.

However, we are using ShimLauncher class to launch evaluator. we will require reef-bridge-client.jar to be in global directory as well, so evaluator could access it.

The code right now is working because reef-bridge-client.jar is added together with dlls in HelloREEF.cs. The problem is exposed in a inappropriate compilation.

